### PR TITLE
Exclude .git from npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ coverage/
 gulpfile.js
 .idea/
 appveyor.yml
+.git/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-filter-github-emojis",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
npm is supposed to ignore this by default, but in v2.0.2 the `.git`
folder was included in the published hexo-filter-github-emojis module.
This causes problems when doing `npm install` again, because it sees a
git repo where it expects a bare npm package.

```
npm ERR! path ./node_modules/hexo-filter-github-emojis
npm ERR! code EISGIT
npm ERR! git ./node_modules/hexo-filter-github-emojis:
Appears to be a git repo or submodule.
npm ERR! git ./node_modules/hexo-filter-github-emojis
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.
```

If you publish again with this patch, all should be fine :v:

Thanks for this package!