### PR TITLE
Fixed code blocks rendering as html

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ if (options.enable !== false) {
   hexo.extend.filter.register('after_post_render', data => {
     if (!options.inject && data['no-emoji']) { return data }
 
-    const $ = cheerio.load(data.content, {decodeEntities: false})
-    const excerpt = cheerio.load(data.excerpt, {decodeEntities: false})
+    const $ = cheerio.load(data.content)
+    const excerpt = cheerio.load(data.excerpt)
 
     if (options.inject) {
       $('body').append(`<script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-filter-github-emojis",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "A Hexo plugin that adds emojis support, using Github Emojis API",
   "main": "index",
   "repository": "crimx/hexo-filter-github-emojis",


### PR DESCRIPTION
On uppy site (https://uppy.io/examples/xhrupload/) we has an issue with code blocks being rendered as html (ignore the 333 number):

![image](https://user-images.githubusercontent.com/7578559/63024847-76a4fb00-bec1-11e9-83fc-b6176cbed362.png)

Here is how it should look:
![image](https://user-images.githubusercontent.com/7578559/63024951-aeac3e00-bec1-11e9-9674-9a1da439f746.png)


We had to downgrade from 2.0.3 to 2.0.0 to fix this, but the real fix is removing the  `{decodeEntities: false}` option.